### PR TITLE
Only create stream_context if curl is not used

### DIFF
--- a/src/org/jsonrpcphp/JsonRPCClient.php
+++ b/src/org/jsonrpcphp/JsonRPCClient.php
@@ -140,15 +140,6 @@ class JsonRPCClient
         }
 
         // performs the HTTP POST
-        $opts = array(
-            'http' => array(
-                'method' => 'POST',
-                'header' => 'Content-type: application/json',
-                'content' => $request
-            )
-        );
-        $context = stream_context_create($opts);
-
         if ($this->enableCurl && is_callable('curl_init')) {
             // use curl when available; solves problems with allow_url_fopen
             $ch = curl_init($this->url);
@@ -164,6 +155,15 @@ class JsonRPCClient
                 throw new \Exception('Unable to connect to ' . $this->url);
             }
         } else {
+            $opts = array(
+                'http' => array(
+                    'method' => 'POST',
+                    'header' => 'Content-type: application/json',
+                    'content' => $request
+                )
+            );
+            $context = stream_context_create($opts);
+
             if ($fp = fopen($this->url, 'r', false, $context)) {
                 $response = '';
                 while ($row = fgets($fp)) {


### PR DESCRIPTION
Admittedly, this is not a dramatic improvement, but I changed this as I was working on something else. 

Before, __call would initialize the $opts and $context variables that are only used by fopen, not cURL. This commit places their initialization in the else-branch of the if-statement that determines if cURL can be used.