### PR TITLE
Introduced configurable path for certificate chain file in JsonRPCClient class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-JSON-RPC PHP
-============
+# JSON-RPC PHP
 
 JSON-RPC PHP is a couple of classes written in PHP implementing respectively
 client and server functionalities of the JSON-RPC protocol.
@@ -8,16 +7,30 @@ This software has originally been developed at http://jsonrpcphp.org/ and has
 been modified to support newer PHP versions and name-spaces; some bugs have
 been fixed.
 
-To install
+# Installation
+
+With composer command line
+
 ```bash
 composer require weberhofer/jsonrpcphp
 ```
-or add this to your composer.json, and ```composer update``` 
 
-```JSON  
+or add this to your composer.json, and `composer update`
+
+```JSON
 {
     "require": {
         "weberhofer/jsonrpcphp": "~2"
     }
 }
 ```
+
+# Dealing with SSL and certificates on the client-side
+
+Depending on the system environment in which the `JsonRPCClient` is executed, 
+a proper resolution of CA bundles might not be possible and connections to the 
+remote server will fail with an error like `unable to get local issuer certificate`. 
+
+In that case, you can fetch the public certificate (or better: the certificate chain) 
+of the server you want to connect to via SSL, store it in your application and provide 
+a path to it to the `JsonRPCClient` on construction.

--- a/src/org/jsonrpcphp/JsonRPCClient.php
+++ b/src/org/jsonrpcphp/JsonRPCClient.php
@@ -27,6 +27,7 @@
  * @license GPLv2+
  * @author sergio <jsonrpcphp@inservibile.org>
  * @author Johannes Weberhofer <jweberhofer@weberhofer.at>
+ * @author Joschka Seydell <joschka@seydell.org>
  */
 namespace org\jsonrpcphp;
 
@@ -46,6 +47,13 @@ class JsonRPCClient
      * @var string
      */
     private $url;
+
+    /**
+     * Path to an SSL chain certificate to be used in cURL requests.
+     * 
+     * @var string
+     */
+    private $serverCertChainFile;
 
     /**
      * Proxy to be used
@@ -80,12 +88,14 @@ class JsonRPCClient
      * Takes the connection parameters
      *
      * @param string $url
+     * @param string $serverCertChainFile
      * @param boolean $debug
      * @param string $proxy
      */
-    public function __construct($url, $debug = false, $proxy = null)
+    public function __construct($url, $serverCertChainFile = '', $debug = false, $proxy = null)
     {
         $this->url = $url;
+        $this->serverCertChainFile = $serverCertChainFile;
         $this->proxy = $proxy;
         $this->debug = ($this->debug === true);
         // message id
@@ -149,6 +159,12 @@ class JsonRPCClient
             // use curl when available; solves problems with allow_url_fopen
             $ch = curl_init($this->url);
             curl_setopt($ch, CURLOPT_POST, 1);
+            // if a custom ssl configuration is provided use this instead of the default settings
+            if (strlen($this->serverCertChainFile) != 0) {
+                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+                curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+                curl_setopt($ch, CURLOPT_CAINFO, $this->serverCertChainFile);
+            }
             curl_setopt($ch, CURLOPT_HTTPHEADER, array(
                 'Content-type: application/json'
             ));


### PR DESCRIPTION
I had a problem with connections to https remotes in a small project of mine and found the solution I propose here. 

Of course, there is no test for this whatsoever (except me assuring that it works on my other project), but I don't know what the testing approach might look like here.

Also, I'm aware that the position of the newly introduced optional constructor parameter might break existing use cases, but I went for my intuition and would like to hear your opinion on that.